### PR TITLE
Update webhook auth to use new digest method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are a few ENV variables that must be configured for this to work. In dev a
 | Variable           | Purpose                                                      |
 | ------------------ | ------------------------------------------------------------ |
 | ZOOM_API_JWT       | Authorization token for Zoom's REST API. You will need to create one for your app in the Zoom Marketplace |
-| ZOOM_WEBHOOK_TOKEN | A token that Zoom includes when it sends webhooks to us, which allows us to authenticatet that the hook is actually coming from Zoom. This is available in Zoom's app configuration where you set up the webhooks. |
+| ZOOM_SECRET_TOKEN | A token that Zoom includes when it sends webhooks to us, which allows us to authenticate that the hook is actually coming from Zoom. This is available in Zoom's app configuration where you set up the webhooks. |
 | MEETING_SECRET     | Any string value that you want to use to obfuscate the meeting dashboard view. For example if you set this value to "crankstations" then the meetings dashboard will be accessible at https://your.app/meetings/crankstations |
 
 ## Zoom Configuration

--- a/README.md
+++ b/README.md
@@ -61,4 +61,3 @@ Ready to run in production? Please [check Phoenix's deployment guides](https://h
   * Docs: https://hexdocs.pm/phoenix
   * Forum: https://elixirforum.com/c/phoenix-forum
   * Source: https://github.com/phoenixframework/phoenix
-

--- a/config/dev.secret.exs.example
+++ b/config/dev.secret.exs.example
@@ -2,6 +2,6 @@ import Config
 
 config :campfire_social_hour,
   jwt: "example.zoom.token",
-  webhook_token: "example.zoom.webhook.token",
+  secret_token: "ABCdef123",
   meeting_secret: "abc123",
   theme: "(techextra|campfire)"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -32,7 +32,7 @@ if config_env() == :prod do
 
   config :campfire_social_hour,
     jwt: System.get_env("ZOOM_API_JWT"),
-    webhook_token: System.get_env("ZOOM_WEBHOOK_TOKEN"),
+    secret_token: System.get_env("ZOOM_SECRET_TOKEN"),
     meeting_secret: System.get_env("MEETING_SECRET"),
     theme: System.get_env("THEME")
 

--- a/config/test.secret.exs.example
+++ b/config/test.secret.exs.example
@@ -2,6 +2,6 @@ import Config
 
 config :campfire_social_hour,
   jwt: "fake.test.token",
-  webhook_token: "fake.zoom.webhook.token",
+  secret_token: "fake.zoom.webhook.token",
   meeting_secret: "abc123",
   theme: "(techextra|campfire)"

--- a/lib/campfire_social_hour/utils.ex
+++ b/lib/campfire_social_hour/utils.ex
@@ -1,0 +1,10 @@
+defmodule CampfireSocialHour.Utils do
+  @moduledoc """
+  Utility functions
+  """
+
+  @doc """
+  Enables easily returning an OK tuple from a pipeline
+  """
+  def ok(term), do: {:ok, term}
+end

--- a/lib/campfire_social_hour_web/controllers/hooks/meeting_controller.ex
+++ b/lib/campfire_social_hour_web/controllers/hooks/meeting_controller.ex
@@ -5,6 +5,16 @@ defmodule CampfireSocialHourWeb.Hooks.MeetingController do
 
   require Logger
 
+  def event(conn, %{"event" => "endpoint.url_validation", "payload" => %{"plainToken" => token}}) do
+    secret = Application.fetch_env!(:campfire_social_hour, :secret_token)
+
+    hash =
+      :crypto.mac(:hmac, :sha256, secret, token)
+      |> Base.encode16(case: :lower)
+
+    json(conn, %{plainToken: token, encryptedToken: hash})
+  end
+
   def event(conn, params) do
     handle_event(params)
 

--- a/lib/campfire_social_hour_web/endpoint.ex
+++ b/lib/campfire_social_hour_web/endpoint.ex
@@ -40,6 +40,7 @@ defmodule CampfireSocialHourWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
+    body_reader: {CampfireSocialHourWeb.Plug.CacheBodyReader, :read_body, []},
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/lib/campfire_social_hour_web/plug/cache_body_reader.ex
+++ b/lib/campfire_social_hour_web/plug/cache_body_reader.ex
@@ -1,0 +1,7 @@
+defmodule CampfireSocialHourWeb.Plug.CacheBodyReader do
+  def read_body(conn, opts) do
+    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
+    conn = update_in(conn.assigns[:raw_body], &[body | (&1 || [])])
+    {:ok, body, conn}
+  end
+end

--- a/lib/campfire_social_hour_web/plug/cache_body_reader.ex
+++ b/lib/campfire_social_hour_web/plug/cache_body_reader.ex
@@ -1,7 +1,7 @@
 defmodule CampfireSocialHourWeb.Plug.CacheBodyReader do
   def read_body(conn, opts) do
     {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
-    conn = update_in(conn.assigns[:raw_body], &[body | (&1 || [])])
+    conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
     {:ok, body, conn}
   end
 end

--- a/lib/campfire_social_hour_web/plug/hook_auth.ex
+++ b/lib/campfire_social_hour_web/plug/hook_auth.ex
@@ -2,6 +2,9 @@ defmodule CampfireSocialHourWeb.Plug.HookAuth do
   import Plug.Conn
   import CampfireSocialHour.Utils, only: [ok: 1]
 
+  @signature_header "x-zm-signature"
+  @timestamp_header "x-zm-request-timestamp"
+
   def init(options), do: options
 
   def call(conn, _opts) do
@@ -19,14 +22,14 @@ defmodule CampfireSocialHourWeb.Plug.HookAuth do
   end
 
   defp signature(conn) do
-    case get_req_header(conn, "x-zm-signature") do
+    case get_req_header(conn, @signature_header) do
       ["v0=" <> signature] -> {:ok, signature}
       _ -> :error
     end
   end
 
   defp timestamp(conn) do
-    case get_req_header(conn, "x-zm-request-timestamp") do
+    case get_req_header(conn, @timestamp_header) do
       [timestamp] -> {:ok, timestamp}
       _ -> :error
     end

--- a/lib/campfire_social_hour_web/plug/hook_auth.ex
+++ b/lib/campfire_social_hour_web/plug/hook_auth.ex
@@ -1,20 +1,46 @@
 defmodule CampfireSocialHourWeb.Plug.HookAuth do
   import Plug.Conn
+  import CampfireSocialHour.Utils, only: [ok: 1]
 
   def init(options), do: options
 
   def call(conn, _opts) do
-    allowed_token = Application.fetch_env!(:campfire_social_hour, :webhook_token)
-    provided_tokens = get_req_header(conn, "authorization")
-
-    authorize(conn, allowed_token in provided_tokens)
+    with {:ok, signature} <- signature(conn),
+         {:ok, timestamp} <- timestamp(conn),
+         {:ok, digest} <- digest(timestamp, conn.assigns.raw_body),
+         true <- authorized?(signature, digest) do
+      conn
+    else
+      _ ->
+        conn
+        |> send_resp(401, "Not authorized")
+        |> halt()
+    end
   end
 
-  defp authorize(conn, _header_match = true), do: conn
-
-  defp authorize(conn, _header_no_match) do
-    conn
-    |> send_resp(401, "Not authorized")
-    |> halt()
+  defp signature(conn) do
+    case get_req_header(conn, "x-zm-signature") do
+      ["v0=" <> signature] -> {:ok, signature}
+      _ -> :error
+    end
   end
+
+  defp timestamp(conn) do
+    case get_req_header(conn, "x-zm-request-timestamp") do
+      [timestamp] -> {:ok, timestamp}
+      _ -> :error
+    end
+  end
+
+  defp digest(timestamp, payload) do
+    :crypto.mac(:hmac, :sha256, secret_token(), digest_msg(timestamp, payload))
+    |> Base.encode16(case: :lower)
+    |> ok()
+  end
+
+  defp digest_msg(timestamp, payload), do: "v0:#{timestamp}:#{payload}"
+
+  defp authorized?(signature, digest), do: Plug.Crypto.secure_compare(signature, digest)
+
+  defp secret_token(), do: Application.fetch_env!(:campfire_social_hour, :secret_token)
 end


### PR DESCRIPTION
Zoom has deprecated the webhook verification token method of verifying endpoints.

The [new default method](https://developers.zoom.us/docs/api/rest/webhook-reference/#verify-with-zooms-header) is to use a header provided by zoom to verify the request via hashing the payload.

ToDo:
- [x] remove `webhook_token` from example
- [x] update readme
- [x] reconcile ENV vars since we now need a new SECRET_TOKEN instead of WEBHOOK_TOKEN
- [x] update tests

